### PR TITLE
Strncpy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(clogger VERSION 0.3.0 LANGUAGES C)
+project(clogger VERSION 0.3.1 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
 

--- a/src/clog.c
+++ b/src/clog.c
@@ -17,7 +17,7 @@ void format_timestamp(char* buffer)
 
     strftime(timestamp_buffer, sizeof timestamp_buffer, "%H:%M:%S", timestamp);
 
-    strcpy(buffer, timestamp_buffer);
+    strncpy(buffer, timestamp_buffer, sizeof(timestamp_buffer));
 }
 
 int clog_messagef(const char* location, const char* format, va_list args)


### PR DESCRIPTION
Switched `strcpy` usage in `format_timestamp` to `strncpy` to prevent potential buffer overflow